### PR TITLE
Change uglifyjs2 command to uglifyjs

### DIFF
--- a/compressor/template.py
+++ b/compressor/template.py
@@ -126,7 +126,7 @@ class Template(object):
         self._run_process(process, file_path)
 
     def uglifyjs(self, file_path):
-        process = Popen(['uglifyjs2', '-o', file_path, file_path],
+        process = Popen(['uglifyjs', '-o', file_path, file_path],
             stdout=PIPE, stderr=PIPE)
         self._run_process(process, file_path)
 


### PR DESCRIPTION
The uglifyjs2 replaced the old uglify (so the command was renamed to uglifyjs only)
